### PR TITLE
Make plugin possible to be installed with SymfonyFlex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "sylius/customer-order-cancellation-plugin",
-    "type": "sylius-plugin",
+    "type": "symfony-bundle",
+    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "customer order cancellation"],
     "description": "Plugin that allows customers to cancel the placed order before it is processed.",
     "license": "MIT",
     "authors": [
@@ -15,10 +16,9 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
-        "sylius/sylius": "~1.3.0",
-        "symfony/symfony": "^3.4|^4.1"
+        "sylius/sylius": "~1.3.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -39,7 +39,13 @@
         "phpstan/phpstan-symfony": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10",
         "phpunit/phpunit": "^6.5",
-        "sylius-labs/coding-standard": "^2.0"
+        "sylius-labs/coding-standard": "^2.0",
+        "symfony/browser-kit": "^3.4|^4.1",
+        "symfony/debug-bundle": "^3.4|^4.1",
+        "symfony/dotenv": "^3.4|^4.1",
+        "symfony/intl": "^3.4|^4.1",
+        "symfony/web-profiler-bundle": "^3.4|^4.1",
+        "symfony/web-server-bundle": "^3.4|^4.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Following an approach proposed in https://github.com/Sylius/RefundPlugin/pull/69 and in https://github.com/Sylius/PluginSkeleton/pull/123/files