### PR TITLE
Bring back "sylius-plugin" composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sylius/customer-order-cancellation-plugin",
-    "type": "symfony-bundle",
+    "type": "sylius-plugin",
     "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "customer order cancellation"],
     "description": "Plugin that allows customers to cancel the placed order before it is processed.",
     "license": "MIT",


### PR DESCRIPTION
**SymfonyFlex** has now support for `sylius-plugin` as a synonymous of `symfony-bundle` :)