### PR TITLE
#21 - fix ConfigTreeBuilder constructor has no parameters

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,9 +14,7 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('sylius_customer_order_cancellation');
 
-        return $treeBuilder;
+        return new TreeBuilder("sylius_customer_order_cancellation_plugin");
     }
 }


### PR DESCRIPTION
 src/DependencyInjection/Configuration.php
 
"$treeBuilder = new TreeBuilder();"  the TreeBuilder needs parameters. And the variable $rootNode is not used.
